### PR TITLE
fix: replace webpack-specific ~ prefix in CSS import docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,20 @@ export class AppComponent {
 
 }
 ```
-Note : For better styling, add below line to your main style.css file
+Note : For better styling, add below line to your main style.css/scss file
 
-```js
-@import "~jsoneditor/dist/jsoneditor.min.css";
+```css
+@import "jsoneditor/dist/jsoneditor.min.css";
 ```
+
+> **Angular 16+ new build system (esbuild):** The old `~` prefix (e.g. `~jsoneditor/...`) is webpack-specific and is not supported by the new esbuild-based builder. Use the path without `~` as shown above, or add the file directly to the `styles` array in `angular.json`:
+>
+> ```json
+> "styles": [
+>   "node_modules/jsoneditor/dist/jsoneditor.min.css",
+>   "src/styles.scss"
+> ]
+> ```
 
 
 ### Forms
@@ -95,7 +104,7 @@ If you have issue with the height of the component, you can try one of those sol
 When you import CSS:
 
 ```css
-@import "~jsoneditor/dist/jsoneditor.min.css";
+@import "jsoneditor/dist/jsoneditor.min.css";
 textarea.jsoneditor-text{min-height:350px;}
 ```
 

--- a/projects/ang-jsoneditor/README.md
+++ b/projects/ang-jsoneditor/README.md
@@ -71,11 +71,20 @@ export class AppComponent {
 
 }
 ```
-Note : For better styling, add below line to your main style.css file
+Note : For better styling, add below line to your main style.css/scss file
 
-```js
-@import "~jsoneditor/dist/jsoneditor.min.css";
+```css
+@import "jsoneditor/dist/jsoneditor.min.css";
 ```
+
+> **Angular 16+ new build system (esbuild):** The old `~` prefix (e.g. `~jsoneditor/...`) is webpack-specific and is not supported by the new esbuild-based builder. Use the path without `~` as shown above, or add the file directly to the `styles` array in `angular.json`:
+>
+> ```json
+> "styles": [
+>   "node_modules/jsoneditor/dist/jsoneditor.min.css",
+>   "src/styles.scss"
+> ]
+> ```
 
 
 ### Forms
@@ -109,7 +118,7 @@ If you have issue with the height of the component, you can try one of those sol
 When you import CSS:
 
 ```css
-@import "~jsoneditor/dist/jsoneditor.min.css";
+@import "jsoneditor/dist/jsoneditor.min.css";
 textarea.jsoneditor-text{min-height:350px;}
 ```
 


### PR DESCRIPTION
## Problem

Fixes #150

The `@import "~jsoneditor/dist/jsoneditor.min.css"` syntax uses a webpack-specific `~` tilde prefix that is **not supported** by Angular's new esbuild-based build system (Angular 16+). Users migrating to the new build system get this error:

```
✘ [ERROR] Could not resolve "~jsoneditor/dist/jsoneditor.min.css"
```

## Fix

Updated both READMEs to drop the `~` prefix — this syntax works with both webpack (old builder) and esbuild (new builder).

Also added a note explaining the cause and an alternative approach using the `angular.json` `styles` array, which avoids the CSS `@import` entirely.

## Live Demo

Try it here: **https://mariohmol.github.io/ang-jsoneditor/**

## Test plan

- [ ] Verify `@import "jsoneditor/dist/jsoneditor.min.css"` works in a project using the new Angular build system (`"builder": "@angular-devkit/build-angular:application"`)
- [ ] Verify it still works in webpack-based projects (`"builder": "@angular-devkit/build-angular:browser"`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)