### PR TITLE
docs: clarify Angular 17+ minimum requirement, add Angular 21 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Angular Json Editor (wrapper for [jsoneditor](https://github.com/josdejong/jsone
 
 **[Live Demo](https://mariohmol.github.io/ang-jsoneditor/)** | [StackBlitz template](https://stackblitz.com/edit/ang-jsoneditor)
 
-Working with Angular 17 / 18 / 19 / 20.
+Working with Angular 17 / 18 / 19 / 20 / 21. Requires Angular 17 or higher.
 
 ![Demo Image](/src/assets/printDemo.png)
 


### PR DESCRIPTION
## Summary

- Updates the README compatibility line to include Angular 21
- Explicitly states "Requires Angular 17 or higher" to prevent confusion for users on older Angular versions

Closes #137

## Context

Issue #137 reports a TypeScript compile error where `ComponentDeclaration` inputs don't satisfy the `{ [key: string]: string }` constraint. This happens because the user's Angular version is older than ~14.2, which used a different format. The library uses Angular 17+ signal APIs (`model()`, `input()`, `output()`), so Angular 17+ is a hard requirement — the peer dependency already enforces this. The README just didn't make it explicit enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)