### PR TITLE
fix: initialize mainMenuBar, navigationBar, statusBar to true by default

### DIFF
--- a/projects/ang-jsoneditor/src/lib/jsoneditor.spec.ts
+++ b/projects/ang-jsoneditor/src/lib/jsoneditor.spec.ts
@@ -1,6 +1,7 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { JsonEditor } from './jsoneditor';
+import { JsonEditorOptions } from './jsoneditoroptions';
 
 describe('JsoneditorComponent', () => {
   let component: JsonEditor;
@@ -21,5 +22,22 @@ describe('JsoneditorComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('JsonEditorOptions defaults', () => {
+    it('should default mainMenuBar to true', () => {
+      const options = new JsonEditorOptions();
+      expect(options.mainMenuBar).toBe(true);
+    });
+
+    it('should default navigationBar to true', () => {
+      const options = new JsonEditorOptions();
+      expect(options.navigationBar).toBe(true);
+    });
+
+    it('should default statusBar to true', () => {
+      const options = new JsonEditorOptions();
+      expect(options.statusBar).toBe(true);
+    });
   });
 });

--- a/projects/ang-jsoneditor/src/lib/jsoneditoroptions.ts
+++ b/projects/ang-jsoneditor/src/lib/jsoneditoroptions.ts
@@ -160,5 +160,8 @@ export class JsonEditorOptions {
     this.mode = 'tree';
     this.search = true;
     this.indentation = 2;
+    this.mainMenuBar = true;
+    this.navigationBar = true;
+    this.statusBar = true;
   }
 }


### PR DESCRIPTION
## Summary

- `JsonEditorOptions` declared `mainMenuBar`, `navigationBar`, and `statusBar` as `boolean` but never initialized them in the constructor, leaving them as `undefined`
- Newer versions of the underlying `jsoneditor` library stopped treating `undefined` as the documented `true` default, causing the bars to disappear
- Fixes by explicitly setting all three to `true` in the constructor, matching the documented behavior

Closes #133

## Test plan

- [ ] `JsonEditorOptions` defaults test: `mainMenuBar`, `navigationBar`, and `statusBar` are each verified to be `true` on a fresh instance in `jsoneditor.spec.ts`
- [ ] Workaround from issue (explicitly setting to `true`) remains valid and unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)